### PR TITLE
remove unnecessary debug mode in bash

### DIFF
--- a/regression.sh
+++ b/regression.sh
@@ -21,7 +21,6 @@ getliblistfromcore() {
     # For each line start extracting the sharelibrary paths once we see
     # the text line "Shared Object Path" in the raw gdb output. Append this
     # in the an output file.
-    set +x
     local STARTPR=0
     while IFS=' ' read -r f1 f2 f3 f4 f5 f6 f7 fdiscard; do
         if [[ $STARTPR == 1 && "$f4" != "" ]]; then
@@ -31,7 +30,6 @@ getliblistfromcore() {
                 STARTPR=1
         fi
     done < "${BASE}/cores/gdbout.txt"
-    set -x
 
     # Cleanup the tmp file for gdb output
     rm -f ${BASE}/cores/gdbout.txt


### PR DESCRIPTION
Reading console logs become difficult with each echo coming twice once for debug mode and again for echo.
Let us use proper echo statements wherever required.
